### PR TITLE
Add reference docs: watching, expensive notebooks, config, reactivity

### DIFF
--- a/skills/marimo-notebook/SKILL.md
+++ b/skills/marimo-notebook/SKILL.md
@@ -275,3 +275,7 @@ pytest <notebook.py>
 - For state management and reactivity [STATE.md](references/STATE.md)
 - For deployment of marimo notebooks [DEPLOYMENT.md](references/DEPLOYMENT.md)
 - For custom interactive widgets with anywidget [ANYWIDGET.md](references/ANYWIDGET.md)
+- For external editing and `--watch` mode [WATCHING.md](references/WATCHING.md)
+- For expensive notebooks (caching, lazy eval, mo.stop) [EXPENSIVE.md](references/EXPENSIVE.md)
+- For configuration (pyproject.toml, marimo.toml) [CONFIGURATION.md](references/CONFIGURATION.md)
+- For reactivity model (DAG, variable scoping, mutations) [REACTIVITY.md](references/REACTIVITY.md)

--- a/skills/marimo-notebook/references/CONFIGURATION.md
+++ b/skills/marimo-notebook/references/CONFIGURATION.md
@@ -1,0 +1,37 @@
+# Configuration
+
+## Two Scopes
+
+1. **App config** — per-notebook, stored in the `.py` file header. Configure via the gear icon (top-right): notebook width, title, custom CSS, custom HTML head.
+2. **User config** — global, stored in `$XDG_CONFIG_HOME/marimo/marimo.toml`. Runtime, display, hotkeys, autosave, formatting, server settings.
+
+## Priority (Highest → Lowest)
+
+1. PEP 723 script metadata block in the notebook file
+2. `pyproject.toml` — project-level overrides
+3. User config (`marimo.toml`) — global defaults
+
+## pyproject.toml
+
+```toml
+[tool.marimo.formatting]
+line_length = 120
+
+[tool.marimo.display]
+default_width = "full"
+
+[tool.marimo.runtime]
+default_sql_output = "native"
+watcher_on_save = "autorun"
+```
+
+## Config Discovery
+
+marimo searches for `.marimo.toml` in: current directory → parent directories → home directory → XDG config directory.
+
+## Useful Commands
+
+```bash
+marimo config show       # view current config and file location
+marimo config describe   # list all available config options
+```

--- a/skills/marimo-notebook/references/CONFIGURATION.md
+++ b/skills/marimo-notebook/references/CONFIGURATION.md
@@ -3,7 +3,7 @@
 ## Two Scopes
 
 1. **App config** — per-notebook, stored in the `.py` file header. Configure via the gear icon (top-right): notebook width, title, custom CSS, custom HTML head.
-2. **User config** — global, stored in `$XDG_CONFIG_HOME/marimo/marimo.toml`. Runtime, display, hotkeys, autosave, formatting, server settings.
+2. **User config** — global, typically stored in `~/.config/marimo/marimo.toml`. Runtime, display, hotkeys, autosave, formatting, server settings.
 
 ## Priority (Highest → Lowest)
 

--- a/skills/marimo-notebook/references/EXPENSIVE.md
+++ b/skills/marimo-notebook/references/EXPENSIVE.md
@@ -1,0 +1,88 @@
+# Expensive Notebooks
+
+## mo.stop()
+
+Halt cell execution when a condition is met:
+
+```python
+@app.cell
+def _(mo, data):
+    mo.stop(data is None, mo.md("Waiting for data..."))
+    # Only runs if data is not None
+    result = process(data)
+    return (result,)
+```
+
+Pair with `mo.ui.run_button()` for manual triggers:
+
+```python
+@app.cell
+def _(mo):
+    run_btn = mo.ui.run_button(label="Run analysis")
+    run_btn
+    return (run_btn,)
+
+@app.cell
+def _(mo, run_btn, data):
+    mo.stop(not run_btn.value)
+    result = expensive_analysis(data)
+    return (result,)
+```
+
+## mo.cache
+
+In-memory cache for the current session. Results are reused when inputs match:
+
+```python
+@mo.cache
+def fetch_data(query: str):
+    return db.execute(query)
+```
+
+Works as a decorator or context manager.
+
+## mo.persistent_cache
+
+Disk-based cache that persists across notebook restarts:
+
+```python
+@mo.persistent_cache
+def train_model(params):
+    return heavy_training(params)
+```
+
+## mo.lazy()
+
+Defer rendering and computation until needed:
+
+```python
+# Only render table when it scrolls into view
+mo.lazy(mo.ui.table(large_df))
+
+# Only compute when tab is selected
+mo.ui.tabs({
+    "Summary": summary,
+    "Details": mo.lazy(lambda: expensive_query()),
+})
+```
+
+## Runtime Configuration
+
+- Disable autorun on cell changes for long-running notebooks
+- Disable startup autorun to prevent automatic execution on open
+- Disable individual cells temporarily during editing
+
+## Memory Management
+
+Wrap intermediate computations in functions so local variables get freed:
+
+```python
+@app.cell
+def _():
+    def _compute():
+        large_data = load_everything()
+        result = summarize(large_data)
+        return result  # large_data is freed here
+    output = _compute()
+    return (output,)
+```

--- a/skills/marimo-notebook/references/REACTIVITY.md
+++ b/skills/marimo-notebook/references/REACTIVITY.md
@@ -1,0 +1,68 @@
+# Reactivity
+
+## The DAG
+
+marimo statically analyzes each cell to build a directed acyclic graph:
+
+- **References** = global variables the cell reads (function parameters)
+- **Definitions** = global variables the cell creates (return tuple)
+
+When a cell runs, all cells that reference its definitions automatically run. Execution order is determined by the DAG, not cell position on the page.
+
+## Variable Uniqueness
+
+Every global variable must be defined by exactly one cell. This prevents ambiguity in the dependency graph.
+
+If you need the same name in multiple cells, use underscore-prefixed cell-local variables:
+
+```python
+@app.cell
+def _():
+    _temp = expensive_computation()
+    result_a = summarize(_temp)
+    return (result_a,)
+
+@app.cell
+def _():
+    _temp = different_computation()  # no conflict, _temp is cell-local
+    result_b = summarize(_temp)
+    return (result_b,)
+```
+
+## Mutations Are Not Tracked
+
+marimo does **not** detect mutations like `.append()`, attribute assignment, or in-place DataFrame operations across cells.
+
+```python
+# BAD — mutation in another cell, marimo won't re-run dependents
+# Cell 1
+items = [1, 2, 3]
+# Cell 2
+items.append(4)  # invisible to the DAG
+
+# GOOD — create a new variable
+# Cell 2
+extended = items + [4]
+```
+
+Mutations within the same cell that defines the variable are fine:
+
+```python
+@app.cell
+def _(pd):
+    df = pd.DataFrame({"a": [1, 2]})
+    df["b"] = [3, 4]  # same cell, fine
+    return (df,)
+```
+
+## Deleting Cells
+
+Deleting a cell removes its global variables from memory. Cells that referenced those variables become invalidated.
+
+## Disabling Cells
+
+Disable a cell to prevent it and its dependents from running. Re-enabling triggers a re-run if upstream cells changed while it was disabled.
+
+## Lazy Evaluation
+
+Instead of auto-running dependents, mark them stale for manual execution. Configure in runtime settings or use `mo.lazy()` for specific elements.

--- a/skills/marimo-notebook/references/WATCHING.md
+++ b/skills/marimo-notebook/references/WATCHING.md
@@ -1,0 +1,55 @@
+# External Editing and Watch Mode
+
+## The Problem
+
+marimo loads the notebook file into memory at startup. After that, it works from its in-memory state and does **not** watch the file for external changes. If you edit the `.py` file externally (vim, VSCode, another agent), marimo won't see it. When any cell is saved in the marimo UI, it writes its in-memory version back to disk, **overwriting your external edits**.
+
+## Solution: --watch
+
+```bash
+marimo edit --watch notebook.py
+```
+
+This monitors the file for changes and streams them to the browser editor. By default, synced code appears as "stale" — the user manually runs cells via the "Run" button or the `runStale` hotkey.
+
+For apps:
+
+```bash
+marimo run --watch notebook.py
+```
+
+This auto-refreshes when file changes are detected.
+
+## Auto-Execute After External Edits
+
+Add to `pyproject.toml` so affected cells run automatically when the file changes:
+
+```toml
+[tool.marimo.runtime]
+watcher_on_save = "autorun"
+```
+
+## Install watchdog for Performance
+
+Without `watchdog`, marimo falls back to polling:
+
+```bash
+pip install watchdog
+```
+
+## Module Autoreloading
+
+Watch imported `.py` modules for changes (not just the notebook file):
+
+1. Enable in notebook settings → Runtime → Module Autoreloading
+2. Two modes:
+   - **Autorun**: automatically executes cells affected by module changes
+   - **Lazy**: marks affected cells as stale for manual execution
+
+The reloader tracks changes recursively through the import chain.
+
+Use case: develop logic in Python modules, use the notebook as an orchestrating DAG.
+
+## Autosave
+
+Make sure autosave is enabled in User Settings → Editor → Autosave for the best watch experience.

--- a/skills/marimo-notebook/references/WATCHING.md
+++ b/skills/marimo-notebook/references/WATCHING.md
@@ -50,6 +50,6 @@ The reloader tracks changes recursively through the import chain.
 
 Use case: develop logic in Python modules, use the notebook as an orchestrating DAG.
 
-## Autosave
+## Responding to other files
 
-Make sure autosave is enabled in User Settings → Editor → Autosave for the best watch experience.
+marimo has `mo.watch.file` and `mo.watch.file` utilities that can cause cells to update when a file/folder updates. 


### PR DESCRIPTION
## Summary

Adds four new reference files to the `marimo-notebook` skill covering topics not currently documented:

- **WATCHING.md** — `--watch` flag for external editing, `watcher_on_save` config, module autoreloading, and the common gotcha where marimo overwrites external edits from other editors/agents
- **EXPENSIVE.md** — `mo.stop`, `mo.cache`, `mo.persistent_cache`, `mo.lazy`, run buttons for gating expensive operations, and memory management patterns
- **CONFIGURATION.md** — `pyproject.toml` settings, `marimo.toml` user config, config priority chain, and useful `marimo config` commands
- **REACTIVITY.md** — DAG model, variable uniqueness rule, mutation limitations, cell-local variables with `_` prefix, cell disabling, and lazy evaluation

Also updates SKILL.md to link these new references in the "Additional resources" section.

## Motivation

While using marimo with an external AI coding agent (Claude Code), we ran into the watch mode issue multiple times — the agent would edit the `.py` file, but marimo's in-memory state would overwrite those changes on the next cell save. The existing skill doesn't mention `--watch` or this behavior. The other reference files cover frequently needed topics (caching expensive operations, configuration, understanding reactivity) that complement the existing references.