### PR TITLE
docs: add Available skills listing to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ pull requests are welcome. You can also join our
 [Discord](https://discord.com/invite/QdpFxJWhyt) or
 [Reddit](https://www.reddit.com/r/marimo_notebook/) to get in touch.
 
+## Available skills
+
+| Skill | Description |
+|-------|-------------|
+| [`marimo-notebook`](skills/marimo-notebook) | Write a marimo notebook in a Python file in the right format. |
+| [`jupyter-to-marimo`](skills/jupyter-to-marimo) | Convert a Jupyter notebook (`.ipynb`) to a marimo notebook (`.py`). |
+| [`streamlit-to-marimo`](skills/streamlit-to-marimo) | Convert a Streamlit app to a marimo notebook. |
+| [`anywidget`](skills/anywidget) | Generate anywidget components for marimo notebooks. |
+| [`marimo-batch`](skills/marimo-batch) | Prepare a marimo notebook for a scheduled / batch run. |
+| [`wasm-compatibility`](skills/wasm-compatibility) | Check whether a marimo notebook is WebAssembly (WASM) compatible and report issues. |
+| [`add-molab-badge`](skills/add-molab-badge) | Add "Open in molab" badge(s) linking to marimo notebooks in READMEs, docs, or websites. |
+| [`implement-paper`](skills/implement-paper) | Implement a research paper as an interactive marimo notebook, together with the user. |
+| [`implement-paper-auto`](skills/implement-paper-auto) | Implement a research paper in a marimo notebook fully automatically (no extra input). |
+| [`auto-paper-demo`](skills/auto-paper-demo) | Make a demo of a research paper in a marimo notebook fully automatically. |
+
 ## What are skills?
 
 Skills are folders of instructions, scripts, and resources


### PR DESCRIPTION
Adds an **Available skills** section to the README — a table listing all 10 skills in the repo with a one-line description each, drawn from each skill's `SKILL.md` frontmatter and linked to its folder. This lets users see the catalog at a glance instead of opening each skill directory.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)