### PR TITLE
fix: repair make sync target paths and document all reference copies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ Current shared references:
 | Source | Copied to |
 |--------|-----------|
 | `skills/anywidget/SKILL.md` | `skills/marimo-notebook/references/ANYWIDGET.md` |
+| `skills/anywidget/SKILL.md` | `skills/auto-paper-demo/references/ANYWIDGET.md` |
+| `skills/anywidget/SKILL.md` | `skills/implement-paper-auto/references/ANYWIDGET.md` |
 | `skills/anywidget/SKILL.md` | `skills/implement-paper/references/anywidget.md` |
 
 After editing `skills/anywidget/SKILL.md`, run:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 sync:
 	cp skills/anywidget/SKILL.md skills/marimo-notebook/references/ANYWIDGET.md
-	cp skills/anywidget/SKILL.md skills/make-paper-demo/references/ANYWIDGET.md
+	cp skills/anywidget/SKILL.md skills/auto-paper-demo/references/ANYWIDGET.md
+	cp skills/anywidget/SKILL.md skills/implement-paper-auto/references/ANYWIDGET.md
 	cp skills/anywidget/SKILL.md skills/implement-paper/references/anywidget.md


### PR DESCRIPTION
## Summary
`make sync` was broken and incomplete.

## Changes
- It copied to `skills/make-paper-demo/references/ANYWIDGET.md`, but that directory was renamed to `auto-paper-demo`, so `make sync` failed with "No such file or directory". Fix the path.
- A fourth real copy, `skills/implement-paper-auto/references/ANYWIDGET.md`, was never synced. Add it.
- The `CLAUDE.md` shared-references table listed only 2 of the 4 actual copies. Complete it.

All four reference files are currently byte-identical to `skills/anywidget/SKILL.md`, so this is maintenance rot rather than intentional divergence; `make sync` now succeeds with a clean tree.

AI was used for assistance.
